### PR TITLE
Fix link in GraphQL code snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Every translator will be credited on any site that makes use of the translations
 
 You can get extra data such as the completion percentage for a locale or the untranslated strings via our API, available at:
 
-- https://graphiql-internal.devographics.com
+- https://graphiql-internal.devographics.com/
 
 Here is a sample query:
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Here is a sample query:
 
 ```graphql
 query GetLocaleData {
-  locale(localeId: "de-DE") {
+  locale(localeId: de_DE) {
     completion
     totalCount
     translatedCount

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Every translator will be credited on any site that makes use of the translations
 
 You can get extra data such as the completion percentage for a locale or the untranslated strings via our API, available at:
 
-- https://graphiql.stateofjs.com/
+- https://graphiql-internal.devographics.com
 
 Here is a sample query:
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Here is a sample query:
 
 ```graphql
 query GetLocaleData {
-  locale(localeId: de_DE) {
+  locale(localeId: "de-DE") {
     completion
     totalCount
     translatedCount


### PR DESCRIPTION
Fix error message
> **Warning**
> Enum "LocaleID" cannot represent non-enum value: "de-DE". Did you mean the enum value "de_DE"

```json
{
  "errors": [
    {
      "message": "Enum \"LocaleID\" cannot represent non-enum value: \"de-DE\". Did you mean the enum value \"de_DE\"?",
      "locations": [
        {
          "line": 2,
          "column": 20
        }
      ],
      "extensions": {
        "code": "GRAPHQL_VALIDATION_FAILED"
      }
    }
  ]
}
```

# Changes
* Use underscore notation (POSIX or "XPG") instead of dash (IETF/BCP 47)
* Use enum instead of string (removal of double quotes)