### PR TITLE
Fix translation team link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ These strings appear in both.
 
 ## Joining Translation Teams
 
-It's recommended you join the [translation team](https://github.com/orgs/StateOfJS/teams/translators/teams) for the language you want to translate.
+It's recommended you join the [translation team](https://github.com/orgs/Devographics/teams) for the language you want to translate. In our case it is [de-DE](https://github.com/orgs/Devographics/teams/de-de).
 
 ## Local Development
 


### PR DESCRIPTION
Fix the translation team link in the [`README.md`](https://github.com/Devographics/locale-de-DE/blob/main/README.md) file.

The issue has been reported here: https://github.com/Devographics/locale-de-DE/pull/3#issuecomment-1617510533